### PR TITLE
net: lwm2m: Way to pass a destination hostname to socket

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -94,6 +94,12 @@ struct lwm2m_ctx {
 	 */
 	int tls_tag;
 
+	/** When MBEDTLS SNI is enabled socket must be set with destination
+	 *  hostname server.
+	 */
+	char *desthostname;
+	uint16_t desthostnamelen;
+
 	/** Client can set load_credentials function as a way of overriding
 	 *  the default behavior of load_tls_credential() in lwm2m_engine.c
 	 */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -144,6 +144,6 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 int  lwm2m_socket_add(struct lwm2m_ctx *ctx);
 void lwm2m_socket_del(struct lwm2m_ctx *ctx);
 int  lwm2m_socket_start(struct lwm2m_ctx *client_ctx);
-int  lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls, bool is_firmware_uri);
+int  lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmware_uri);
 
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -386,8 +386,7 @@ static void firmware_transfer(void)
 	server_addr = firmware_uri;
 #endif
 
-	ret = lwm2m_parse_peerinfo(server_addr, &firmware_ctx.remote_addr,
-				   &firmware_ctx.use_dtls, true);
+	ret = lwm2m_parse_peerinfo(server_addr, &firmware_ctx, true);
 	if (ret < 0) {
 		LOG_ERR("Failed to parse server URI.");
 		goto error;


### PR DESCRIPTION
net: lwm2m: When mbedtls CONFIG_MBEDTLS_SERVER_NAME_INDICATION is
enabled, a destination hostname must be passed to socket to properly
connect do lwm2m server.

Passing lwm2m context to lwm2m_parse_peerinfo

Signed-off-by: Jair Jack <jack@icatorze.com.br>