### PR TITLE
net: lwm2m: Supported Protocol to pull firmware update must be optional

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -78,6 +78,9 @@ static uint32_t led_state;
 
 static struct lwm2m_ctx client;
 
+/* Array with supported PULL firmware update protocols */
+static uint8_t supported_protocol[1] = {0};
+
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 #define TLS_TAG			1
 
@@ -369,6 +372,9 @@ static int lwm2m_setup(void)
 	lwm2m_firmware_set_write_cb(firmware_block_received_cb);
 #endif
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
+	lwm2m_engine_create_res_inst("5/0/8/0");
+	lwm2m_engine_set_res_data("5/0/8/0", &supported_protocol, sizeof(supported_protocol), 0);
+
 	lwm2m_firmware_set_update_cb(firmware_update_cb);
 #endif
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -49,7 +49,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* resource state variables */
 static uint8_t update_state;
 static uint8_t update_result;
-static uint8_t supported_protocol;
 static uint8_t delivery_method;
 static char package_uri[PACKAGE_URI_LEN];
 
@@ -335,8 +334,8 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 			  &update_result, sizeof(update_result));
 	INIT_OBJ_RES_OPTDATA(FIRMWARE_PACKAGE_NAME_ID, res, i, res_inst, j);
 	INIT_OBJ_RES_OPTDATA(FIRMWARE_PACKAGE_VERSION_ID, res, i, res_inst, j);
-	INIT_OBJ_RES_DATA(FIRMWARE_UPDATE_PROTO_SUPPORT_ID, res, i, res_inst, j,
-			  &supported_protocol, sizeof(supported_protocol));
+	INIT_OBJ_RES_MULTI_OPTDATA(FIRMWARE_UPDATE_PROTO_SUPPORT_ID, res, i,
+					   res_inst, j, 1, false);
 	INIT_OBJ_RES_DATA(FIRMWARE_UPDATE_DELIV_METHOD_ID, res, i, res_inst, j,
 			  &delivery_method, sizeof(delivery_method));
 


### PR DESCRIPTION
The supported protocol must be delivered to the firmware update object
as optional, then configured in the application.

This information is device/server dependent so does not can be fixed
in library.

Signed-off-by: Jair Jack <jack@icatorze.com.br>